### PR TITLE
fix: 修复支付宝小程序无法自定义header属性的问题

### DIFF
--- a/platforms/alipay/initNativeApi.js
+++ b/platforms/alipay/initNativeApi.js
@@ -166,9 +166,8 @@ function adaptRequest(options) {
   options['headers'] = defaultHeaders;
 
   if (options['header']) {
-    for (const k in options['headers']) {
-      const lowerK = k.toLocaleLowerCase();
-      options['headers'][k] = options['header'][lowerK];
+    for (const k in options['header']) {
+      options['headers'][k] = options['header'][k];
     }
 
     delete options['header'];


### PR DESCRIPTION
支付宝小程序无法自定义header属性