### PR TITLE
modify shared request return

### DIFF
--- a/platforms/shared/request.js
+++ b/platforms/shared/request.js
@@ -123,9 +123,9 @@ export default class RequestManager {
 
   dispatchRequest (options) {
     return send(options).then(response => {
-      return { options, ...response };
+      return { config: options, ...response };
     }, reason => {
-      return Promise.reject({ options, ...reason });
+      return Promise.reject({ config: options, ...reason });
     });
   }
 }

--- a/platforms/shared/request.js
+++ b/platforms/shared/request.js
@@ -5,7 +5,7 @@ const RequestQueue = {
   MAX_REQUEST: 10,
   waitQueue: [],
   runningQueue: [],
-  push(task) {
+  push (task) {
     const { waitQueue, runningQueue, MAX_REQUEST } = this;
 
     if (runningQueue.length < MAX_REQUEST) {
@@ -14,7 +14,7 @@ const RequestQueue = {
       waitQueue.push(task);
     }
   },
-  run(task) {
+  run (task) {
     const { waitQueue, runningQueue } = this;
 
     runningQueue.push(task);
@@ -31,10 +31,10 @@ const RequestQueue = {
   }
 };
 
-function getEnvContext() {
+function getEnvContext () {
   let env = getEnv();
 
-  switch(env) {
+  switch (env) {
     case 'wechat':
       return wx;
     case 'swan':
@@ -48,13 +48,13 @@ function getEnvContext() {
   }
 }
 
-function send(options) {
+function send (options) {
   const ctx = getEnvContext();
 
   let requestTask;
   const p = new Promise((resolve, reject) => {
     RequestQueue.push({
-      run() {
+      run () {
         return new Promise(resolveTask => {
 
           options.success = res => {
@@ -100,10 +100,10 @@ export default class RequestManager {
     };
   }
 
-  request(options) {
+  request (options) {
     options = options || {};
 
-    let chain = [ this.dispatchRequest, undefined ];
+    let chain = [this.dispatchRequest, undefined];
     let promise = Promise.resolve(options);
 
     this.interceptors.before.forEach(interceptor => {
@@ -114,18 +114,18 @@ export default class RequestManager {
       chain.push(interceptor.fulfilled, interceptor.rejected);
     });
 
-    while(chain.length) {
+    while (chain.length) {
       promise = promise.then(chain.shift(), chain.shift());
     }
 
     return promise;
   }
 
-  dispatchRequest(options) {
+  dispatchRequest (options) {
     return send(options).then(response => {
-      return response;
+      return { options, ...response };
     }, reason => {
-      return Promise.reject(reason);
+      return Promise.reject({ options, ...reason });
     });
   }
 }


### PR DESCRIPTION
参照axios拦截器数据返回，修改megalo-api在微信小程序上的数据返回格式。新增请求时options的数据返回。方便在拦截中知道数据返回具体是哪个接口的。这样也便于在拦截器中统一对请求失败的接口进行统一的重试处理